### PR TITLE
Genea2022 "report as broken" and "reload" button implementation

### DIFF
--- a/design/style.css
+++ b/design/style.css
@@ -218,6 +218,11 @@ td.stopButton {
   margin : 0 auto;
 }
 
+.reloadControlElement {
+  width: 6.0em !important;
+  margin : 0 auto;
+}
+
 #mainUp {
   width : 100%;
 }

--- a/lib/webmushra/business/PageManager.js
+++ b/lib/webmushra/business/PageManager.js
@@ -49,13 +49,13 @@ PageManager.prototype.getCurrentPage = function () {
 };
 
 PageManager.prototype.reportBroken = function () {
-  currPage = pageManager.getCurrentPage()
+  currPage = pageManager.getCurrentPage();
   if (currPage instanceof VideoPC) {
     for (i = 0; i < currPage.ratings.length; ++i) {
       currPage.ratings[i].value = 99;
     }
   }
-  this.nextPage()
+  this.nextPage();
 }
 
 PageManager.prototype.nextPage = function () {

--- a/lib/webmushra/business/PageManager.js
+++ b/lib/webmushra/business/PageManager.js
@@ -48,6 +48,16 @@ PageManager.prototype.getCurrentPage = function () {
   return this.pages[this.pagesIndex];
 };
 
+PageManager.prototype.reportBroken = function () {
+  currPage = pageManager.getCurrentPage()
+  if (currPage instanceof VideoPC) {
+    for (i = 0; i < currPage.ratings.length; ++i) {
+      currPage.ratings[i].value = 99;
+    }
+  }
+  this.nextPage()
+}
+
 PageManager.prototype.nextPage = function () {
   ++this.pagesIndex;
 
@@ -72,7 +82,6 @@ PageManager.prototype.nextPage = function () {
             }
         }
       }
-
 
       var id = this.parentElementId;
       $("#"+id).empty();
@@ -122,8 +131,6 @@ PageManager.prototype.restart = function () {
     this.pagesIndex = -1;
     this.start();
 };
-
-
 
 PageManager.prototype.getPageVariableName = function (_page) {
     for (var i = 0; i < this.pages.length; ++i) {

--- a/lib/webmushra/business/PageTemplateRenderer.js
+++ b/lib/webmushra/business/PageTemplateRenderer.js
@@ -13,6 +13,7 @@ function PageTemplateRenderer(_pageManager, _showButtonPreviousPage, _language) 
   this.language = _language;
   this.pageManager = _pageManager;
   this.lockNextButtonQueued = false;
+  this.lockReportButtonQueued = false;
   
   this.callbacksEventRefreshed = [];  
 }
@@ -57,20 +58,32 @@ PageTemplateRenderer.prototype.renderNavigation = function(_parentId) {
     renderedSomething = true;
   }
 
-  
+  if (this.pageManager.getCurrentPage() instanceof VideoPC) {
+    if (this.pageManager.getPageIndex() < (this.pageManager.getNumPages() - 1)) {
+      var buttonReport = $("<button id='__button_report' data-role='button' data-inline='true' onclick='" + this.pageManager.getPageManagerVariableName() + ".reportBroken();'>" + this.pageManager.getLocalizer().getFragment(this.language, "reportButton")  + "</button>");
+      buttonReport.css('margin-right', '24em');
+      if (this.lockReportButtonQueued) {
+        buttonReport.attr('disabled', 'disabled');
+      }
+      $('#' + this.navigationId).append(buttonReport);
+      renderedSomething = true;
+    }
+  }
+
   if (this.pageManager.getPageIndex() < (this.pageManager.getNumPages() - 1)) {
     var buttonNext = $("<button id='__button_next' data-role='button' data-inline='true' onclick='" + this.pageManager.getPageManagerVariableName() + ".nextPage();'>" + this.pageManager.getLocalizer().getFragment(this.language, "nextButton")  + "</button>");
     if (this.lockNextButtonQueued) {
-    	buttonNext.attr('disabled', 'disabled');
+      buttonNext.attr('disabled', 'disabled');
     }
     $('#' + this.navigationId).append(buttonNext);
     renderedSomething = true;
   }
-  
+
   if (!renderedSomething) {
     $('#' + this.navigationId).remove();
   }
   this.lockNextButtonQueued = false;
+  this.lockReportButtonQueued = false;
 };
 
 PageTemplateRenderer.prototype.lockNextButton = function() {
@@ -81,11 +94,21 @@ PageTemplateRenderer.prototype.lockNextButton = function() {
   }
 };
 
+PageTemplateRenderer.prototype.lockReportButton = function() {
+  if ($('#__button_report').length > 0) {
+  	$('#__button_report').attr('disabled', 'disabled');
+  } else {
+  	this.lockReportButtonQueued = true;
+  }
+};
+
 PageTemplateRenderer.prototype.unlockNextButton = function() {
   $('#__button_next').removeAttr('disabled');
 };
 
-
+PageTemplateRenderer.prototype.unlockReportButton = function() {
+  $('#__button_report').removeAttr('disabled');
+};
 
 PageTemplateRenderer.prototype.refresh = function() {
     $('#' + this.progressbarId).progressbar('option', 'value', ((this.pageManager.getPageIndex()) / (this.pageManager.getNumPages()-1)) * 100);

--- a/lib/webmushra/nls/nls.js
+++ b/lib/webmushra/nls/nls.js
@@ -12,6 +12,7 @@ nls['de'] = new Object();
 nls['fr'] = new Object();
 
 // Buttons
+nls['en']['reportButton'] = "Report as broken";
 nls['en']['nextButton'] = "Next";
 nls['en']['previousButton'] = "Previous"; 
 nls['en']['playButton'] = "Play";
@@ -19,6 +20,7 @@ nls['en']['stopButton'] = "Stop";
 nls['en']['pauseButton'] = "Pause";
 nls['en']['sendButton'] = "Submit results";
 
+nls['de']['reportButton'] = "Als kaputt melden";
 nls['de']['nextButton'] = "Nächste Seite";
 nls['de']['previousButton'] = "Vorherige Seite"; 
 nls['de']['playButton'] = "Start";
@@ -26,6 +28,7 @@ nls['de']['stopButton'] = "Stopp";
 nls['de']['pauseButton'] = "Pause";
 nls['de']['sendButton'] = "Ergebnisse senden";
 
+nls['fr']['reportButton'] = "Signaler la vidéo comme cassée";
 nls['fr']['nextButton'] = "Suivant";
 nls['fr']['previousButton'] = "Précédent";
 nls['fr']['playButton'] = "Play";

--- a/lib/webmushra/nls/nls.js
+++ b/lib/webmushra/nls/nls.js
@@ -13,6 +13,7 @@ nls['fr'] = new Object();
 
 // Buttons
 nls['en']['reportButton'] = "Report as broken";
+nls['en']['reloadButton'] = "Reload";
 nls['en']['nextButton'] = "Next";
 nls['en']['previousButton'] = "Previous"; 
 nls['en']['playButton'] = "Play";
@@ -21,6 +22,7 @@ nls['en']['pauseButton'] = "Pause";
 nls['en']['sendButton'] = "Submit results";
 
 nls['de']['reportButton'] = "Als kaputt melden";
+nls['de']['reloadButton'] = "Nachladen";
 nls['de']['nextButton'] = "Nächste Seite";
 nls['de']['previousButton'] = "Vorherige Seite"; 
 nls['de']['playButton'] = "Start";
@@ -29,6 +31,7 @@ nls['de']['pauseButton'] = "Pause";
 nls['de']['sendButton'] = "Ergebnisse senden";
 
 nls['fr']['reportButton'] = "Signaler la vidéo comme cassée";
+nls['fr']['reloadButton'] = "Rechargé";
 nls['fr']['nextButton'] = "Suivant";
 nls['fr']['previousButton'] = "Précédent";
 nls['fr']['playButton'] = "Play";

--- a/lib/webmushra/pages/VideoPC.js
+++ b/lib/webmushra/pages/VideoPC.js
@@ -112,7 +112,6 @@ function createXPathFromElement(elm) {
   return segs.length ? '/' + segs.join('/') : null;
 }
 
-
 VideoPC.prototype.render = function (_parent) {
   var div = $("<div></div>");
   var global = this;
@@ -148,7 +147,8 @@ VideoPC.prototype.render = function (_parent) {
         global.ratings[0].value = true;
         global.ratings[1].value = false;
         if(global.watched){
-            global.pageTemplateRenderer.unlockNextButton();
+          global.pageTemplateRenderer.unlockNextButton();
+          global.pageTemplateRenderer.unlockReportButton();
         }
   });
   var cr = $("<input type='radio' id='right-video' name='selection' value='right-video'><label for='right-video'>The character in the video on the <i>right</i></label>");
@@ -157,6 +157,7 @@ VideoPC.prototype.render = function (_parent) {
     global.ratings[1].value = true;
     if(global.watched){
         global.pageTemplateRenderer.unlockNextButton();
+        global.pageTemplateRenderer.unlockReportButton();
     }
   });
   var eq = $("<input type='radio' id='both-video' name='selection' value='both-video'><label for='both-video'>They are equal</label>");
@@ -165,8 +166,10 @@ VideoPC.prototype.render = function (_parent) {
     global.ratings[1].value = false;
     if(global.watched){
         global.pageTemplateRenderer.unlockNextButton();
+        global.pageTemplateRenderer.unlockReportButton();
     }
   });
+
   div.append(p);
   /* We always put video1 on the left and video2 on the right */
   this.videoVisualizer = new VideoPCVisualizer(div, this.conditions);
@@ -201,7 +204,6 @@ VideoPC.prototype.render = function (_parent) {
   equal.append(eq);
 
 };
-
 
 VideoPC.prototype.save = function () {
   this.time += new Date() - this.startTimeOnPage;
@@ -255,10 +257,10 @@ VideoPC.prototype.postCheck = function() {
   });
 };
 
-
 VideoPC.prototype.load = function () {
   this.startTimeOnPage = new Date();
   this.pageTemplateRenderer.lockNextButton();
+  this.pageTemplateRenderer.lockReportButton();
 };
 
 VideoPC.prototype.store = function () {

--- a/lib/webmushra/pages/VideoPage.js
+++ b/lib/webmushra/pages/VideoPage.js
@@ -207,6 +207,18 @@ VideoPage.prototype.render = function (_parent) {
     // })(i);
   }
 
+  var buttonReload = $(
+    "<button data-role='button' class='center' onclick='" +
+      this.pageManager.getPageVariableName(this) +
+      ".btnCallbackReload();'>" +
+      this.pageManager
+        .getLocalizer()
+        .getFragment(this.language, "reloadButton") +
+      "</button>"
+  );
+  buttonReload.attr("id", "buttonReload");
+  tdConditionPlayScale.append(buttonReload);
+
   // ratings
   var trConditionRatings = $("<tr id='tr_ConditionRatings'></tr>");
   tableMushra.append(trConditionRatings);
@@ -301,6 +313,13 @@ VideoPage.prototype.render = function (_parent) {
 VideoPage.prototype.pause = function () {
   this.videoVisualizer.pause();
 };
+
+VideoPage.prototype.btnCallbackReload = function () {
+  $(".audioControlElement").text(
+    this.pageManager.getLocalizer().getFragment(this.language, "playButton")
+  );
+  this.videoVisualizer.reload();
+}
 
 VideoPage.prototype.btnCallbackCondition = function (_index) {
   this.currentItem = _index;

--- a/lib/webmushra/pages/VideoPage.js
+++ b/lib/webmushra/pages/VideoPage.js
@@ -208,7 +208,7 @@ VideoPage.prototype.render = function (_parent) {
   }
 
   var buttonReload = $(
-    "<button data-role='button' class='center' onclick='" +
+    "<button data-role='button' class='center reloadControlElement' onclick='" +
       this.pageManager.getPageVariableName(this) +
       ".btnCallbackReload();'>" +
       this.pageManager

--- a/lib/webmushra/video/VideoVisualizer.js
+++ b/lib/webmushra/video/VideoVisualizer.js
@@ -78,6 +78,11 @@ VideoVisualizer.prototype.pause = function () {
   return;
 };
 
+VideoVisualizer.prototype.reload = function () {
+  (new Vimeo.Player(this.currentVideo)).unload();
+  return;
+};
+
 VideoVisualizer.prototype.getConditions = function () {
   return this.conditions;
 };

--- a/lib/webmushra/video/VideoVisualizer.js
+++ b/lib/webmushra/video/VideoVisualizer.js
@@ -79,7 +79,9 @@ VideoVisualizer.prototype.pause = function () {
 };
 
 VideoVisualizer.prototype.reload = function () {
-  (new Vimeo.Player(this.currentVideo)).unload();
+  if (this.currentVideo) {
+    (new Vimeo.Player(this.currentVideo)).loadVideo(this.conditions[this.currentVideoIndex].getFilepath());
+  }
   return;
 };
 


### PR DESCRIPTION
This PR implements two buttons which extend the HEMVIP interface:

**Reload button**
- is shown ONLY on the single-video pages (`VideoPage.js`)
- will not do anything unless at least one video has been selected through the `Play` buttons
- will reload the currently-selected video

**Report button**
- is shown ONLY on the pairwise comparison pages (`VideoPC.js`)
- behaves the same as the `Next` button (is disabled, enabled later)
- when pressed, the values of the two video ratings will be set to `99`, and the study goes to the next page

The only unchecked part is the localization strings for the `report` and `reload` buttons in `nls.js`. The translations are probably OK, but it is best to confirm with someone else.